### PR TITLE
Encrypt password

### DIFF
--- a/__tests__/signup.ts
+++ b/__tests__/signup.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import request from "supertest";
 import db from "@/db";
 import { signup, genIdPw, genPort, getLoginCookies } from "@/utils/testutil";
@@ -10,7 +11,11 @@ test("signup", async () => {
   const res = await signup(username, password, app);
   expect(res.status).toEqual(200);
   const user = await db.user.findUnique({ where: { username } });
-  expect(user?.password).toBe(password);
+  expect(user?.password).toBe(
+    crypto
+      .pbkdf2Sync(password, user?.salt!, 100000, 64, "sha512")
+      .toString("base64")
+  );
 });
 
 test("signup with already used username", async () => {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,8 +13,8 @@ model User {
   username String  @unique @db.VarChar(255)
   password String  @db.VarChar(255)
   refresh  String? @db.VarChar(255)
+  salt     String  @db.VarChar(255)
   // TODO:
-  // salt     String  @db.VarChar(255)
   // email    String  @unique @db.VarChar(255)
   diary    Diary[]
   todo     Todo[]


### PR DESCRIPTION
- USER
  - 암호화에 사용될 salt 필드 추가
- 회원가입
  - salt 생성하여 요청 받은 비밀번호를 암호화한 뒤 DB에 같이 저장
  - 테스트 시에도 salt로 암호화된 값과 비교
- 로그인 
  - salt 가져와 요청 받은 비밀번호를 암호화한 뒤 DB의 암호화된 비밀번호와 비교